### PR TITLE
Modify jwt iat from valueOf to unix

### DIFF
--- a/src/services/token.service.js
+++ b/src/services/token.service.js
@@ -8,7 +8,7 @@ const AppError = require('../utils/AppError');
 const generateToken = (userId, expires, secret = config.jwt.secret) => {
   const payload = {
     sub: userId,
-    iat: moment().valueOf(),
+    iat: moment().unix(),
     exp: expires.unix(),
   };
   return jwt.sign(payload, secret);


### PR DESCRIPTION
iat expressed as seconds from epoch instead of milliseconds from epoch

According to the moment.js docs

> moment#valueOf simply outputs the number of milliseconds since the Unix Epoch, just like Date#valueOf. To get a Unix timestamp (the number of seconds since the epoch) from a Moment, use moment#unix.

Since JWTs need a unix timestamp for the iat claim, I modified it accordingly.
This should solve the "Token used before issued" error