### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,12 +278,12 @@ If the user making the request does not have the required permissions to access 
 
 ## Logging
 
-Import the logger from `src/utils/logger.js`. It is using the [Winston](https://github.com/winstonjs/winston) logging library.
+Import the logger from `src/config/logger.js`. It is using the [Winston](https://github.com/winstonjs/winston) logging library.
 
 Logging should be done according to the following severity levels (ascending order from most important to least important):
 
 ```javascript
-const logger = require('<path to src>/utils/logger');
+const logger = require('<path to src>/config/logger');
 
 logger.error('message'); // level 0
 logger.warn('message'); // level 1


### PR DESCRIPTION
In the README file, the location of `logger.js` is changed from `src/utils/` to `src/config/`.