### PR TITLE
disable swagger-ui in production

### DIFF
--- a/src/routes/v1/index.js
+++ b/src/routes/v1/index.js
@@ -2,11 +2,37 @@ const express = require('express');
 const authRoute = require('./auth.route');
 const userRoute = require('./user.route');
 const docsRoute = require('./docs.route');
+const config = require('../../config/config');
 
 const router = express.Router();
 
-router.use('/auth', authRoute);
-router.use('/users', userRoute);
-router.use('/docs', docsRoute);
+const defaultRoutes = [
+  {
+    path: '/auth',
+    route: authRoute,
+  },
+  {
+    path: '/users',
+    route: userRoute,
+  },
+];
+
+const devRoutes = [
+  // routes available only in development mode
+  {
+    path: '/docs',
+    route: docsRoute,
+  },
+];
+
+defaultRoutes.forEach((route) => {
+  router.use(route.path, route.route);
+});
+
+if (config.env !== 'production') {
+  devRoutes.forEach((route) => {
+    router.use(route.path, route.route);
+  });
+}
 
 module.exports = router;


### PR DESCRIPTION
The Swagger user interface can be very convenient for development. However, owing to security concerns, and depending on the nature of the project, we might not want to allow this behavior in a production environment.

Based on discussion in #58.